### PR TITLE
Change SymbolIcon.MeasureOverride() to fit in small borders

### DIFF
--- a/FluentIcons.Avalonia/SymbolIcon.cs
+++ b/FluentIcons.Avalonia/SymbolIcon.cs
@@ -61,7 +61,9 @@ namespace FluentIcons.Avalonia
                 InvalidateText();
             }
 
-            return new Size(FontSize, FontSize);
+            return new Size(
+                Math.Min(availableSize.Width, FontSize),
+                Math.Min(availableSize.Height, FontSize));
         }
 
         public override void Render(DrawingContext context)

--- a/FluentIcons.FluentAvalonia/SymbolIcon.cs
+++ b/FluentIcons.FluentAvalonia/SymbolIcon.cs
@@ -70,7 +70,9 @@ namespace FluentIcons.FluentAvalonia
                 InvalidateText();
             }
 
-            return new Size(FontSize, FontSize);
+            return new Size(
+                Math.Min(availableSize.Width, FontSize),
+                Math.Min(availableSize.Height, FontSize));
         }
 
         public override void Render(DrawingContext context)

--- a/FluentIcons.WPF/SymbolIcon.cs
+++ b/FluentIcons.WPF/SymbolIcon.cs
@@ -73,10 +73,9 @@ namespace FluentIcons.WPF
                 InvalidateText();
             }
 
-            double w = Math.Min(availableSize.Width, FontSize);
-            double h = Math.Min(availableSize.Height, FontSize);
-
-            return new Size(w, h);
+            return new Size(
+                Math.Min(availableSize.Width, FontSize),
+                Math.Min(availableSize.Height, FontSize));
         }
 
         protected override void OnRender(DrawingContext context)

--- a/FluentIcons.WPF/SymbolIcon.cs
+++ b/FluentIcons.WPF/SymbolIcon.cs
@@ -73,7 +73,10 @@ namespace FluentIcons.WPF
                 InvalidateText();
             }
 
-            return new Size(FontSize, FontSize);
+            double w = Math.Min(availableSize.Width, FontSize);
+            double h = Math.Min(availableSize.Height, FontSize);
+
+            return new Size(w, h);
         }
 
         protected override void OnRender(DrawingContext context)


### PR DESCRIPTION
Hi,

I would like to use the nuget package but often the icon font size I want is 22 for example, but the space I want to put it in is 16x16.  In a case like this there is enough space to display the icon nicely, though currently it will be rendered partly outside the visible area.  This pull request will make the icon display centered in the available space in cases where that space is smaller than the font size.

Hopefully a pic is attached below showing difference, and some sample xaml with icons in various configurations.

![Results](https://github.com/davidxuang/FluentIcons/assets/5113210/83c2101e-1f9a-45c7-ada8-53de70a9d339)


`
    <Grid>
        <Grid.Resources>
            <Style TargetType="Border">
                <Setter Property="Margin" Value="10" />
                <Setter Property="HorizontalAlignment" Value="Center" />
                <Setter Property="VerticalAlignment" Value="Center" />
                <Setter Property="BorderBrush" Value="Black" />
                <Setter Property="BorderThickness" Value="1" />
            </Style>
        </Grid.Resources>

        <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10">
            <TextBlock FontSize="20">Old</TextBlock>

            <StackPanel Orientation="Horizontal">
                <Border Width="10" Height="33" >
                    <wpf:SymbolIcon Symbol="CaretDown" FontSize="22"  />
                </Border>
                <Border Width="33" Height="13" >
                    <wpf:SymbolIcon Symbol="CaretDown" FontSize="22"  />
                </Border>
                <Border>
                    <wpf:SymbolIcon Symbol="CaretDown" FontSize="22" />
                </Border>
                <Border Width="13" Height="13">
                    <wpf:SymbolIcon Symbol="CaretDown" FontSize="22"  />
                </Border>
                <Border >
                    <wpf:SymbolIcon Symbol="CaretDown" FontSize="22" Width="100" Height="100" />
                </Border>

            </StackPanel>

            <TextBlock FontSize="20" Margin="0 10 0 0">New</TextBlock>

            <StackPanel Orientation="Horizontal">

                <Border Width="10" Height="33" >
                    <wpfTest:SymbolIcon2 Symbol="CaretDown" FontSize="22" />
                </Border>
                <Border Width="33" Height="13" >
                    <wpfTest:SymbolIcon2 Symbol="CaretDown" FontSize="22"  />
                </Border>
                <Border>
                    <wpfTest:SymbolIcon2 Symbol="CaretDown" FontSize="22" />
                </Border>
                <Border Width="13" Height="13" >
                    <wpfTest:SymbolIcon2 Symbol="CaretDown" FontSize="22" />
                </Border>
                <Border Width="100" Height="100" >
                    <wpfTest:SymbolIcon2 Symbol="CaretDown" FontSize="22" />
                </Border>

            </StackPanel>
        </StackPanel>
    </Grid>

`