### PR TITLE
[UWP/WinUI] Specify `CopyToOutputDirectory` for transitive content files

### DIFF
--- a/FluentIcons.Uwp/build/net8.0-windows10.0.26100.0/FluentIcons.Uwp.props
+++ b/FluentIcons.Uwp/build/net8.0-windows10.0.26100.0/FluentIcons.Uwp.props
@@ -1,7 +1,9 @@
 <Project>
 
   <ItemGroup Condition="'$(UseUwp)' == 'true' and '$(OutputType)' == 'WinExe'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**" Visible="false" />
+    <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/FluentIcons.Uwp/build/uap10.0.17763.0/FluentIcons.Uwp.props
+++ b/FluentIcons.Uwp/build/uap10.0.17763.0/FluentIcons.Uwp.props
@@ -3,6 +3,7 @@
   <ItemGroup Condition="'$(OutputType)' == 'AppContainerExe'">
     <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/FluentIcons.WinUI/build/net6.0-windows10.0.17763.0/FluentIcons.WinUI.props
+++ b/FluentIcons.WinUI/build/net6.0-windows10.0.17763.0/FluentIcons.WinUI.props
@@ -1,7 +1,9 @@
 <Project>
 
   <ItemGroup Condition="'$(UseWinUI)' == 'true' and '$(OutputType)' == 'WinExe'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**" />
+    <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
   </ItemGroup>
 
 </Project>

--- a/FluentIcons.WinUI/build/net6.0-windows10.0.17763.0/FluentIcons.WinUI.props
+++ b/FluentIcons.WinUI/build/net6.0-windows10.0.17763.0/FluentIcons.WinUI.props
@@ -2,8 +2,8 @@
 
   <ItemGroup Condition="'$(UseWinUI)' == 'true' and '$(OutputType)' == 'WinExe'">
     <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**">
-		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</Content>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/FluentIcons.WinUI/build/net8.0-windows10.0.17763.0/FluentIcons.WinUI.props
+++ b/FluentIcons.WinUI/build/net8.0-windows10.0.17763.0/FluentIcons.WinUI.props
@@ -1,7 +1,9 @@
 <Project>
 
   <ItemGroup Condition="'$(UseWinUI)' == 'true' and '$(OutputType)' == 'WinExe'">
-    <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**" Visible="false" />
+    <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**" Visible="false">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
   </ItemGroup>
 
 </Project>

--- a/FluentIcons.WinUI/build/net8.0-windows10.0.17763.0/FluentIcons.WinUI.props
+++ b/FluentIcons.WinUI/build/net8.0-windows10.0.17763.0/FluentIcons.WinUI.props
@@ -2,8 +2,8 @@
 
   <ItemGroup Condition="'$(UseWinUI)' == 'true' and '$(OutputType)' == 'WinExe'">
     <Content Include="$(MSBuildThisFileDirectory)..\..\contentTransitive\**" Visible="false">
-		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</Content>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/771e0b17-ea8d-4b37-bc82-364ce221a3c0)

After:
![image](https://github.com/user-attachments/assets/523f1283-17ef-4b00-9a8b-acebdc5bb93c)
