### PR TITLE
Fix WinUI warnings by upgrading Win2D and WinUI packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,10 +8,10 @@
     <PackageVersion Include="FluentAvaloniaUI" Version="2.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
     <PackageVersion Include="Microsoft.Windows.SDK.CPP" Version="10.0.26100.2161" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2651.64" />


### PR DESCRIPTION
This PR addresses the WinUI-generated warnings as reported in #45.

To resolve this issue, I have upgraded the `Microsoft.Graphics.Win2D` package and the associated `Microsoft.WindowsAppSDK` (WinUI 3) version.

While the Windows App SDK was updated to a newer patch, it remains within the **v1.6** release cycle. Since this update stays within the same minor version (v1.6.x), it ensures compatibility with the existing codebase while resolving the warnings generated by the previous version.

#### **Changes**

* Upgraded `Microsoft.Graphics.Win2D` to version 1.3.2.
* Update `Microsoft.WindowsAppSDK` to v1.6 to meet the dependency requirements of `Microsoft.Graphics.Win2D` 1.3.2.

Fixes #45